### PR TITLE
Fix getTableName & getJoinTableName for Doctrine 2.4.*

### DIFF
--- a/lib/Doctrine/Common/DataFixtures/Purger/ORMPurger.php
+++ b/lib/Doctrine/Common/DataFixtures/Purger/ORMPurger.php
@@ -128,7 +128,7 @@ class ORMPurger implements PurgerInterface
             ) {
                 continue;
             }
-            
+
             $orderedTables[] = $this->getTableName($class, $platform);
         }
 
@@ -195,7 +195,7 @@ class ORMPurger implements PurgerInterface
     private function getAssociationTables(array $classes, AbstractPlatform $platform)
     {
         $associationTables = array();
-        
+
         foreach ($classes as $class) {
             foreach ($class->associationMappings as $assoc) {
                 if ($assoc['isOwningSide'] && $assoc['type'] == ClassMetadata::MANY_TO_MANY) {
@@ -206,25 +206,35 @@ class ORMPurger implements PurgerInterface
 
         return $associationTables;
     }
-    
+
     /**
-     * 
+     *
      * @param \Doctrine\ORM\Mapping\ClassMetadata $class
      * @param \Doctrine\DBAL\Platforms\AbstractPlatform $platform
      * @return string
      */
-    private function getTableName($class, $platform){
+    private function getTableName($class, $platform)
+    {
+        if (isset($class->table['schema']) && !method_exists($class, 'getSchemaName')) {
+            return $class->table['schema'].'.'.$this->em->getConfiguration()->getQuoteStrategy()->getTableName($class, $platform);
+        }
+
         return $this->em->getConfiguration()->getQuoteStrategy()->getTableName($class, $platform);
     }
-    
+
     /**
-     * 
+     *
      * @param array            $association
      * @param \Doctrine\ORM\Mapping\ClassMetadata    $class
      * @param \Doctrine\DBAL\Platforms\AbstractPlatform $platform
      * @return string
      */
-    private function getJoinTableName($assoc, $class, $platform){
+    private function getJoinTableName($assoc, $class, $platform)
+    {
+        if (isset($assoc['joinTable']['schema']) && !method_exists($class, 'getSchemaName')) {
+            return $assoc['joinTable']['schema'].'.'.$this->em->getConfiguration()->getQuoteStrategy()->getJoinTableName($assoc, $class, $platform);
+        }
+
         return $this->em->getConfiguration()->getQuoteStrategy()->getJoinTableName($assoc, $class, $platform);
     }
 }

--- a/tests/Doctrine/Tests/Common/DataFixtures/Purger/ORMPurgerTest.php
+++ b/tests/Doctrine/Tests/Common/DataFixtures/Purger/ORMPurgerTest.php
@@ -4,6 +4,7 @@
 namespace Doctrine\Tests\Common\DataFixtures;
 
 use Doctrine\Common\DataFixtures\Purger\ORMPurger;
+use Doctrine\ORM\Version as ORMVersion;
 use ReflectionClass;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Tools\Setup;
@@ -19,7 +20,7 @@ class ORMPurgerTest extends BaseTest
     const TEST_ENTITY_USER_WITH_SCHEMA = 'Doctrine\Tests\Common\DataFixtures\TestEntity\UserWithSchema';
     const TEST_ENTITY_QUOTED = 'Doctrine\Tests\Common\DataFixtures\TestEntity\Quoted';
 
-    
+
     public function testGetAssociationTables()
     {
         $em = $this->getMockAnnotationReaderEntityManager();
@@ -32,7 +33,7 @@ class ORMPurgerTest extends BaseTest
         $associationTables = $method->invokeArgs($purger, array(array($metadata), $platform));
         $this->assertEquals($associationTables[0], 'readers.author_reader');
     }
-    
+
     public function testGetAssociationTablesQuoted()
     {
         $em = $this->getMockAnnotationReaderEntityManager();
@@ -45,9 +46,14 @@ class ORMPurgerTest extends BaseTest
         $associationTables = $method->invokeArgs($purger, array(array($metadata), $platform));
         $this->assertEquals($associationTables[0], '"INSERT"');
     }
-    
+
     public function testTableNameWithSchema()
     {
+        $isDoctrine25 = (ORMVersion::compare('2.5.0') <= 0);
+        if (!$isDoctrine25) {
+            $this->markTestSkipped('@Table schema attribute is not supported in Doctrine < 2.5.0');
+        }
+
         $em = $this->getMockAnnotationReaderEntityManager();
         $metadata = $em->getClassMetadata(self::TEST_ENTITY_USER_WITH_SCHEMA);
         $platform = $em->getConnection()->getDatabasePlatform();


### PR DESCRIPTION
Hello, 

I fixed your branch for Doctrine 2.4.*
I skipped the `ORMPurgerTest::testTableNameWithSchema` for Doctrine < 2.5.0, it can't work as the `schema` attribute is never set. 
